### PR TITLE
Select directory of kops versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,15 @@ $ kopsenv list-remote
 ...
 ```
 
+## Configuration directory
+
+If you would like to configure a different directory than the `KOPSENV_ROOT` to install and manager your Kops versions,
+you can specify a `KOPSENV_CONF_DIR` environment variable.
+
+```sh
+export KOPSENV_CONF_DIR="$HOME/.kopsversions/
+```
+
 ## .kops-version
 
 If you put `.kops-version` file on your project root, or in your home directory, kopsenv detects it and use the version written in it. If the version is `latest` or `latest:<regex>`, the latest matching version currently installed will be selected.

--- a/bin/kopsenv
+++ b/bin/kopsenv
@@ -24,8 +24,19 @@ if [ -z "${KOPSENV_ROOT}" ]; then
 else
   KOPSENV_ROOT="${KOPSENV_ROOT%/}"
 fi
+
 export KOPSENV_ROOT
+
+if [ -z "${KOPSENV_CONF_DIR}" ]; then
+  KOPSENV_CONF_DIR="${KOPSENV_ROOT}"
+else
+  KOPSENV_CONF_DIR="${KOPSENV_CONF_DIR%/}"
+fi
+
+export KOPSENV_CONF_DIR
+
 PATH="${KOPSENV_ROOT}/libexec:${PATH}"
+
 export PATH
 export KOPSENV_DIR="${PWD}"
 

--- a/libexec/kopsenv-exec
+++ b/libexec/kopsenv-exec
@@ -11,12 +11,12 @@
 #   kopsenv exec plan
 #
 # is equivalent to:
-#   PATH="$KOPSENV_ROOT/versions/0.7.0/bin:$PATH" kops plan
+#   PATH="$KOPSENV_CONF_DIR/versions/0.7.0/bin:$PATH" kops plan
 
 set -e
 [ -n "${KOPSENV_DEBUG}" ] && set -x
 
 export KOPSENV_VERSION="$(kopsenv-version-name)"
-KOPS_BIN_PATH="${KOPSENV_ROOT}/versions/${KOPSENV_VERSION}/kops"
+KOPS_BIN_PATH="${KOPSENV_CONF_DIR}/versions/${KOPSENV_VERSION}/kops"
 export PATH="${KOPS_BIN_PATH}:${PATH}"
 "${KOPS_BIN_PATH}" "${@}"

--- a/libexec/kopsenv-install
+++ b/libexec/kopsenv-install
@@ -9,7 +9,7 @@ declare version_requested version regex
 
 if [ -z "${1}" ]; then
   version_file="$(kopsenv-version-file)"
-  if [ "${version_file}" != "${KOPSENV_ROOT}/version" ]; then
+  if [ "${version_file}" != "${KOPSENV_CONF_DIR}/version" ]; then
     version_requested="$(cat ${version_file} || true)"
   fi
 else
@@ -31,7 +31,7 @@ fi
 version="$(kopsenv-list-remote | grep -e "${regex}" | head -n 1)"
 [ -n "${version}" ] || error_and_die "No versions matching '${1}' found in remote"
 
-dst_path="${KOPSENV_ROOT}/versions/${version}"
+dst_path="${KOPSENV_CONF_DIR}/versions/${version}"
 if [ -f "${dst_path}/kops" ]; then
   echo "Kops v${version} is already installed"
   exit 0

--- a/libexec/kopsenv-list
+++ b/libexec/kopsenv-list
@@ -6,10 +6,10 @@ source ${KOPSENV_ROOT}/libexec/helpers
 [ ${#} -ne 0 ] \
   && error_and_die "usage: kopsenv list"
 
-[ -d "${KOPSENV_ROOT}/versions" ] \
+[ -d "${KOPSENV_CONF_DIR}/versions" ] \
   || error_and_die "No versions available. Please install one with: kopsenv install"
 
-[[ -x "${KOPSENV_ROOT}/versions" && -r "${KOPSENV_ROOT}/versions" ]] \
+[[ -x "${KOPSENV_CONF_DIR}/versions" && -r "${KOPSENV_CONF_DIR}/versions" ]] \
   || error_and_die "kopsenv versions directory is inaccessible!"
 
 print_version () {
@@ -20,6 +20,6 @@ print_version () {
     fi
 }
 
-for local_version in $(ls -1 "${KOPSENV_ROOT}/versions" | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3); do
+for local_version in $(ls -1 "${KOPSENV_CONF_DIR}/versions" | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3); do
     print_version ${local_version}
 done

--- a/libexec/kopsenv-uninstall
+++ b/libexec/kopsenv-uninstall
@@ -9,7 +9,7 @@ declare version_requested version regex
 
 if [ -z "${1}" ]; then
   version_file="$(kopsenv-version-file)"
-  if [ "${version_file}" != "${KOPSENV_ROOT}/version" ];then
+  if [ "${version_file}" != "${KOPSENV_CONF_DIR}/version" ];then
     version_requested="$(cat ${version_file} || true)"
   fi
 else
@@ -31,7 +31,7 @@ fi
 version="$(kopsenv-list | sed -E 's/^(\*| )? //g; s/ \(set by .+\)$//' | grep -e "${regex}" | head -n 1)"
 [ -n "${version}" ] || error_and_die "No versions matching '${1}' found in local"
 
-dst_path="${KOPSENV_ROOT}/versions/${version}"
+dst_path="${KOPSENV_CONF_DIR}/versions/${version}"
 if [ -f "${dst_path}/kops" ]; then 
   info "Uninstall Kops v${version}"
   rm -r "${dst_path}"

--- a/libexec/kopsenv-use
+++ b/libexec/kopsenv-use
@@ -32,10 +32,10 @@ else
   regex="^${version_requested}$"
 fi
 
-[ -d "${KOPSENV_ROOT}/versions" ] \
+[ -d "${KOPSENV_CONF_DIR}/versions" ] \
   || error_and_die "No versions of kops installed. Please install one with: kopsenv install"
 
-version="$(\ls "${KOPSENV_ROOT}/versions" \
+version="$(\ls "${KOPSENV_CONF_DIR}/versions" \
   | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3 \
   | grep -e "${regex}" \
   | head -n 1
@@ -43,7 +43,7 @@ version="$(\ls "${KOPSENV_ROOT}/versions" \
 
 [ -n "${version}" ] || error_and_die "No installed versions of kops matched '${1}'"
 
-target_path=${KOPSENV_ROOT}/versions/${version}
+target_path=${KOPSENV_CONF_DIR}/versions/${version}
 [ -f ${target_path}/kops ] \
   || error_and_die "Version directory for ${version} is present, but the kops binary is not! Manual intervention required."
 [ -x ${target_path}/kops ] \

--- a/libexec/kopsenv-version-file
+++ b/libexec/kopsenv-version-file
@@ -17,4 +17,4 @@ find_local_version_file() {
   return 1
 }
 
-find_local_version_file "${KOPSENV_DIR}" || find_local_version_file "${HOME}" || echo "${KOPSENV_ROOT}/version"
+find_local_version_file "${KOPSENV_DIR}" || find_local_version_file "${HOME}" || echo "${KOPSENV_CONF_DIR}/version"

--- a/libexec/kopsenv-version-name
+++ b/libexec/kopsenv-version-name
@@ -5,7 +5,7 @@ set -e
 [ -n "${KOPSENV_DEBUG}" ] && set -x
 source ${KOPSENV_ROOT}/libexec/helpers
 
-[ -d "${KOPSENV_ROOT}/versions" ] \
+[ -d "${KOPSENV_CONF_DIR}/versions" ] \
   || error_and_die "No versions of kops installed. Please install one with: kopsenv install"
 
 KOPSENV_VERSION_FILE="$(kopsenv-version-file)"
@@ -13,7 +13,7 @@ KOPSENV_VERSION="$(cat "${KOPSENV_VERSION_FILE}" || true)"
 
 if [[ "${KOPSENV_VERSION}" =~ ^latest.*$ ]]; then
   [[ "${KOPSENV_VERSION}" =~ ^latest\:.*$ ]] && regex="${KOPSENV_VERSION##*\:}"
-  version="$(\ls "${KOPSENV_ROOT}/versions" \
+  version="$(\ls "${KOPSENV_CONF_DIR}/versions" \
     | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3 \
     | grep -e "${regex}" \
     | head -n 1
@@ -27,7 +27,7 @@ fi
 
 version_exists() {
   local version="${1}"
-  [ -d "${KOPSENV_ROOT}/versions/${version}" ]
+  [ -d "${KOPSENV_CONF_DIR}/versions/${version}" ]
 }
 
 if version_exists "${KOPSENV_VERSION}"; then


### PR DESCRIPTION
This merge adds a new configuration **KOPSENV_CONF_DIR** to override the path where the kopsenv will search for installed versions.

The default value for this configuration is the KOPSENV_ROOT path.

The KOPSENV_CONF_DIR was required to allow a CI/CD installs any kops version from different clusters when the runner user doesn't have access to the root installation folder.