### PR TITLE
Invoca 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Currently kopsenv supports the following OSes, on x86-64 bit archtecture only:
   ```sh
   $ ln -s ~/.kopsenv/bin/* /usr/local/bin
   ```
-  
+
   On Ubuntu/Debian touching `/usr/local/bin` might require sudo access, but you can create `${HOME}/bin` or `${HOME}/.local/bin` and on next login it will get added to the session `$PATH`
   or by running `. ${HOME}/.profile` it will get added to the current shell session's `$PATH`.
-  
+
   ```sh
   $ mkdir -p ~/.local/bin/
   $ . ~/.profile
@@ -47,6 +47,9 @@ Currently kopsenv supports the following OSes, on x86-64 bit archtecture only:
 ## Usage
 
 ### kopsenv install [version]
+
+
+**IMPORTANT:** Be sure to run `brew uninstall kops` before installing kopsenv
 
 Install a specific version of Kops. Available options for version:
 

--- a/libexec/kopsenv-install
+++ b/libexec/kopsenv-install
@@ -63,5 +63,5 @@ cp "${download_tmp}/${exe_name}" "${dst_path}/kops" || error_and_die "Copy of ${
 
 chmod a+x "${dst_path}/kops" || error_and_die "Unable to set execute on ${dst_path}/kops"
 
-info "Installation of kops v${version} successful"
+info "Installation of kops ${version} successful"
 kopsenv-use "$version"

--- a/libexec/kopsenv-install
+++ b/libexec/kopsenv-install
@@ -40,45 +40,26 @@ fi
 # Check if version_requested contains "invoca", and if does, get version from the Invoca Kops fork
 if [[ "${version_requested}" =~ "invoca" ]]; then
   exe_name="kops"
-  version_url="https://github.com/Invoca/kops/releases/download/${version}/${exe_name}"
+  version_url="https://github.com/Invoca/kops/releases/download/${version}"
 else
-exe_name="kops-$(kops_platform)"
+  exe_name="kops-$(kops_platform)"
   version_url="https://github.com/kubernetes/kops/releases/download/${version}"
 fi
 
-(( "$?" )) && exit $?
+(("$?")) && exit $?
 
 info "Installing Kops ${version}"
 
 # Create a local temporary directory for downloads
 download_tmp="$(mktemp -d kopsenv_download.XXXXXX)" || error_and_die "Unable to create temporary download directory in $(pwd)"
 # Clean it up in case of error
-trap "rm -rf ${download_tmp}" EXIT;
-
-if [[ "${version_requested}" =~ "invoca" ]]; then
-
-  exe_name="kops"
-
-info "Downloading release from ${version_url}"
-curlw -# -f -L -o "${download_tmp}/${exe_name}" "${version_url}" || error_and_die "Download failed"
-
-mkdir -p "${dst_path}" || error_and_die "Failed to make directory ${dst_path}"
-cp "${download_tmp}/${exe_name}" "${dst_path}/kops" || error_and_die "Copy of ${exe_name} from ${download_tmp} to ${dst_path} failed"
-chmod a+x "${dst_path}/kops" || error_and_die "Unable to set execute on ${dst_path}/kops"
-
-
-
-  else
+trap "rm -rf ${download_tmp}" EXIT
 
 info "Downloading release from ${version_url}/${exe_name}"
 curlw -# -f -L -o "${download_tmp}/${exe_name}" "${version_url}/${exe_name}" || error_and_die "Download failed"
 
 mkdir -p "${dst_path}" || error_and_die "Failed to make directory ${dst_path}"
-tar -cvf "${download_tmp}/${exe_name}"
 cp "${download_tmp}/${exe_name}" "${dst_path}/kops" || error_and_die "Copy of ${exe_name} from ${download_tmp} to ${dst_path} failed"
-
-
-fi
 
 chmod a+x "${dst_path}/kops" || error_and_die "Unable to set execute on ${dst_path}/kops"
 

--- a/libexec/kopsenv-install
+++ b/libexec/kopsenv-install
@@ -37,7 +37,13 @@ if [ -f "${dst_path}/kops" ]; then
   exit 0
 fi
 
-version_url="https://github.com/kubernetes/kops/releases/download/${version}"
+# Check if version_requested contains "invoca", and if does, get version from the Invoca Kops fork
+if [[ "${version_requested}" =~ "invoca" ]]; then
+  version_url="https://api.github.com/repos/Invoca/kops/releases/download/${version}"
+else
+  version_url="https://github.com/kubernetes/kops/releases/download/${version}"
+fi
+
 exe_name="kops-$(kops_platform)"
 (( "$?" )) && exit $?
 
@@ -57,4 +63,3 @@ chmod a+x "${dst_path}/kops" || error_and_die "Unable to set execute on ${dst_pa
 
 info "Installation of kops v${version} successful"
 kopsenv-use "$version"
-

--- a/libexec/kopsenv-install
+++ b/libexec/kopsenv-install
@@ -33,32 +33,53 @@ version="$(kopsenv-list-remote | grep -e "${regex}" | head -n 1)"
 
 dst_path="${KOPSENV_ROOT}/versions/${version}"
 if [ -f "${dst_path}/kops" ]; then
-  echo "Kops v${version} is already installed"
+  echo "Kops ${version} is already installed"
   exit 0
 fi
 
 # Check if version_requested contains "invoca", and if does, get version from the Invoca Kops fork
 if [[ "${version_requested}" =~ "invoca" ]]; then
-  version_url="https://api.github.com/repos/Invoca/kops/releases/download/${version}"
+  exe_name="kops"
+  version_url="https://github.com/Invoca/kops/releases/download/${version}/${exe_name}"
 else
+exe_name="kops-$(kops_platform)"
   version_url="https://github.com/kubernetes/kops/releases/download/${version}"
 fi
 
-exe_name="kops-$(kops_platform)"
 (( "$?" )) && exit $?
 
-info "Installing Kops v${version}"
+info "Installing Kops ${version}"
 
 # Create a local temporary directory for downloads
 download_tmp="$(mktemp -d kopsenv_download.XXXXXX)" || error_and_die "Unable to create temporary download directory in $(pwd)"
 # Clean it up in case of error
 trap "rm -rf ${download_tmp}" EXIT;
 
+if [[ "${version_requested}" =~ "invoca" ]]; then
+
+  exe_name="kops"
+
+info "Downloading release from ${version_url}"
+curlw -# -f -L -o "${download_tmp}/${exe_name}" "${version_url}" || error_and_die "Download failed"
+
+mkdir -p "${dst_path}" || error_and_die "Failed to make directory ${dst_path}"
+cp "${download_tmp}/${exe_name}" "${dst_path}/kops" || error_and_die "Copy of ${exe_name} from ${download_tmp} to ${dst_path} failed"
+chmod a+x "${dst_path}/kops" || error_and_die "Unable to set execute on ${dst_path}/kops"
+
+
+
+  else
+
 info "Downloading release from ${version_url}/${exe_name}"
 curlw -# -f -L -o "${download_tmp}/${exe_name}" "${version_url}/${exe_name}" || error_and_die "Download failed"
 
 mkdir -p "${dst_path}" || error_and_die "Failed to make directory ${dst_path}"
+tar -cvf "${download_tmp}/${exe_name}"
 cp "${download_tmp}/${exe_name}" "${dst_path}/kops" || error_and_die "Copy of ${exe_name} from ${download_tmp} to ${dst_path} failed"
+
+
+fi
+
 chmod a+x "${dst_path}/kops" || error_and_die "Unable to set execute on ${dst_path}/kops"
 
 info "Installation of kops v${version} successful"

--- a/libexec/kopsenv-list-remote
+++ b/libexec/kopsenv-list-remote
@@ -12,25 +12,25 @@ fi
 platform="$(kops_platform)"
 (( "$?" )) && exit $?
 
-# List versions from both the Invoca Fork + Upstream Kops repos. We will use the latest version from either repo.
-upstream_json=$(curl -s -L https://api.github.com/repos/kubernetes/kops/releases?per_page=100)
-forked_json=$(curl -s -L https://api.github.com/repos/Invoca/kops/releases?per_page=100)
+# Get releases from both the Invoca fork (https://github.com/Invoca/kops) and the upstream Kops repo (https://github
+# .com/kubernetes/kops)
+urls=("https://api.github.com/repos/kubernetes/kops/releases" "https://api.github.com/repos/Invoca/kops/releases")
 
-(( "$?" )) && exit $?
+all_versions=""
 
-upstream_versions=$(echo "$upstream_json" \
-  | grep 'tag_name' \
-  | sed -E 's/.*"tag_name": "([^"]+)",.*/\1/' \
-  | sort -t. -rn -k1,1 -k2,2 -k3,3 -k4,4 \
-  | uniq)
+for url in "${urls[@]}"; do
+  json=$(curl -s -L "$url?per_page=100")
+  (( "$?" )) && exit $?
 
-forked_versions=$(echo "$forked_json" \
-  | grep 'tag_name' \
-  | sed -E 's/.*"tag_name": "([^"]+)",.*/\1/' \
-  | sort -t. -rn -k1,1 -k2,2 -k3,3 -k4,4 \
-  | uniq)
+  versions=$(echo "$json" \
+    | grep 'tag_name' \
+    | sed -E 's/.*"tag_name": "([^"]+)",.*/\1/' \
+    | grep -v -E '(alpha|beta|gamma)' \
+    | sort -t. -rn -k1,1 -k2,2 -k3,3 -k4,4 \
+    | uniq)
 
-all_versions=$(echo -e "$upstream_versions\n$forked_versions" | sort -t. -rn -k1,1 -k2,2 -k3,3 -k4,4 | uniq)
+  all_versions+="$versions"$'\n'
+done
 
-echo "$all_versions"
-
+# Print versions out in descending order, regardless of which repo they come from
+echo "$all_versions" | sort -t. -rn -k1,1 -k2,2 -k3,3 -k4,4 | uniq

--- a/libexec/kopsenv-list-remote
+++ b/libexec/kopsenv-list-remote
@@ -15,7 +15,11 @@ platform="$(kops_platform)"
 # returned in JSON output from the github API, but there's no other
 # reasonable way to get a list of the current kops versions using
 # only curl + POSIX tools
-json=$(curlw -s -L https://api.github.com/repos/kubernetes/kops/releases?per_page=100)
+
+upstream_json=$(curlw -s -L https://api.github.com/repos/kubernetes/kops/releases?per_page=100)
+fork_json=$(curlw -s -L https://api.github.com/repos/Invoca/kops/releases/latest)
+json="${upstream_json}${fork_json}"
+
 (( "$?" )) && exit $?
 
 echo "$json" \

--- a/libexec/kopsenv-list-remote
+++ b/libexec/kopsenv-list-remote
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
+
 set -e
 [ -n "${KOPSENV_DEBUG}" ] && set -x
 source ${KOPSENV_ROOT}/libexec/helpers
 
-if [ ${#} -ne 0 ];then
+if [ ${#} -ne 0 ]; then
   echo "usage: kopsenv list-remote" 1>&2
   exit 1
 fi
@@ -11,18 +12,25 @@ fi
 platform="$(kops_platform)"
 (( "$?" )) && exit $?
 
-
-
-# List versions from both the Invoca Fork + Upstream Kops repos.  We will u
-upstream_json=$(curlw -s -L https://api.github.com/repos/kubernetes/kops/releases?per_page=100)
-fork_json=$(curlw -s -L https://api.github.com/repos/Invoca/kops/releases?per_page=100)
-json="${upstream_json}${fork_json}"
+# List versions from both the Invoca Fork + Upstream Kops repos. We will use the latest version from either repo.
+upstream_json=$(curl -s -L https://api.github.com/repos/kubernetes/kops/releases?per_page=100)
+forked_json=$(curl -s -L https://api.github.com/repos/Invoca/kops/releases?per_page=100)
 
 (( "$?" )) && exit $?
 
-echo "$json" \
-  | grep 'download/v[0-9\.]\{1,\}/kops-'$platform'"' \
-  | sed 's/^.*download\///; s/\/.*$//' \
+upstream_versions=$(echo "$upstream_json" \
+  | grep 'tag_name' \
+  | sed -E 's/.*"tag_name": "([^"]+)",.*/\1/' \
   | sort -t. -rn -k1,1 -k2,2 -k3,3 -k4,4 \
-  | uniq
+  | uniq)
+
+forked_versions=$(echo "$forked_json" \
+  | grep 'tag_name' \
+  | sed -E 's/.*"tag_name": "([^"]+)",.*/\1/' \
+  | sort -t. -rn -k1,1 -k2,2 -k3,3 -k4,4 \
+  | uniq)
+
+all_versions=$(echo -e "$upstream_versions\n$forked_versions" | sort -t. -rn -k1,1 -k2,2 -k3,3 -k4,4 | uniq)
+
+echo "$all_versions"
 

--- a/libexec/kopsenv-list-remote
+++ b/libexec/kopsenv-list-remote
@@ -15,11 +15,11 @@ platform="$(kops_platform)"
 # returned in JSON output from the github API, but there's no other
 # reasonable way to get a list of the current kops versions using
 # only curl + POSIX tools
-json=$(curlw -s -L https://api.github.com/repos/kubernetes/kops/releases)
+json=$(curlw -s -L https://api.github.com/repos/kubernetes/kops/releases?per_page=100)
 (( "$?" )) && exit $?
 
 echo "$json" \
-  | grep 'download/[0-9\.]\{1,\}/kops-'$platform'"' \
+  | grep 'download/v[0-9\.]\{1,\}/kops-'$platform'"' \
   | sed 's/^.*download\///; s/\/.*$//' \
   | sort -t. -rn -k1,1 -k2,2 -k3,3 -k4,4 \
   | uniq

--- a/libexec/kopsenv-list-remote
+++ b/libexec/kopsenv-list-remote
@@ -11,13 +11,11 @@ fi
 platform="$(kops_platform)"
 (( "$?" )) && exit $?
 
-# This is a bit hacky since it's relying on the formatting of URLs
-# returned in JSON output from the github API, but there's no other
-# reasonable way to get a list of the current kops versions using
-# only curl + POSIX tools
 
+
+# List versions from both the Invoca Fork + Upstream Kops repos.  We will u
 upstream_json=$(curlw -s -L https://api.github.com/repos/kubernetes/kops/releases?per_page=100)
-fork_json=$(curlw -s -L https://api.github.com/repos/Invoca/kops/releases/latest)
+fork_json=$(curlw -s -L https://api.github.com/repos/Invoca/kops/releases?per_page=100)
 json="${upstream_json}${fork_json}"
 
 (( "$?" )) && exit $?

--- a/libexec/kopsenv-use
+++ b/libexec/kopsenv-use
@@ -14,8 +14,8 @@ if [[ "${version_requested}" =~ ^min-required$ ]]; then
   found_min_required="$(kopsenv-min-required)"
 
   if [[ $? -eq 0 ]]; then
-      echo "Min required version is detected as ${found_min_required}"
-      version_requested=${found_min_required}
+    echo "Min required version is detected as ${found_min_required}"
+    version_requested=${found_min_required}
   else
     exit 1
   fi
@@ -51,5 +51,5 @@ target_path=${KOPSENV_ROOT}/versions/${version}
 
 info "Switching to v${version}"
 echo "${version}" > "$(kopsenv-version-file)" || error_and_die "'switch to v${version} failed'"
-kops version client 1>/dev/null || error_and_die "'kops version client' failed. Something is seriously wrong"
+kops version client 1>/dev/null 2>&1 || error_and_die "'kops version client' failed. Something is seriously wrong"
 info "Switching completed"


### PR DESCRIPTION
We're now pulling from two repos, both the upstream and the Invoca-forked version of ops, and we are allowing the user to switch between these repos seamlessly, based on which version of `kops` they select with `kopsenv list-remote`