### PR TITLE
[SHOW] feat: add support for arch arm64

### DIFF
--- a/libexec/helpers
+++ b/libexec/helpers
@@ -29,6 +29,7 @@ kops_platform() {
   local arch
   case "$(uname -m)" in
     x86_64) arch='amd64';;
+    arm64) arch='arm64';;
     *)      error_and_die "Unrecognized/unsupported architecture $(uname -m)";;
   esac
   local os


### PR DESCRIPTION

To fix the below issue:

`[~]$ kopsenv install v1.29.0
kopsenv: kopsenv-list-remote: [ERROR] Unrecognized/unsupported architecture arm64
kopsenv: kopsenv-install: [ERROR] No versions matching 'v1.29.0' found in remote`

adding support for arm64 architecture.